### PR TITLE
Dan/fix/signup text

### DIFF
--- a/src/components/ProfilePic.js
+++ b/src/components/ProfilePic.js
@@ -59,7 +59,7 @@ export default function ProfilePic({ handleMenu }) {
         onMouseOver={handleMenu}
         onClick={handleMenu}
       >
-        <Avatar alt={user.displayName} src={`${user.avatar} | Open Menu`} />
+        <Avatar alt={user.displayName} src={user.avatar || 'Open Menu'} />
       </StyledBadge>
     </div>
   );

--- a/src/components/ProfilePic.js
+++ b/src/components/ProfilePic.js
@@ -56,7 +56,6 @@ export default function ProfilePic({ handleMenu }) {
           horizontal: 'right'
         }}
         variant="dot"
-        onMouseOver={handleMenu}
         onClick={handleMenu}
       >
         <Avatar alt={user.displayName} src={user.avatar || 'Open Menu'} />

--- a/src/pages/Login/DeveloperLogin.js
+++ b/src/pages/Login/DeveloperLogin.js
@@ -8,7 +8,7 @@ const useStyles = makeStyles((theme) => ({
     color: '#ffffff',
     backgroundColor: '#333',
     margin: 15,
-    width: 250,
+    width: 270,
     "&:hover, &:focus": {
       backgroundColor: '#0c0c0c',
     }

--- a/src/pages/Login/DeveloperLogin.js
+++ b/src/pages/Login/DeveloperLogin.js
@@ -35,7 +35,7 @@ export default function DeveloperLogin() {
   return (
     <div className={classes.developer}>
       <Typography variant="h6">
-        Login as a developer
+        Sign up or login as a developer
       </Typography>
       <div className={classes.btnContainer}>
         <Button
@@ -45,7 +45,7 @@ export default function DeveloperLogin() {
           href="http://localhost:5000/auth/github"
         >
           <GitHubIcon className={classes.icon} />
-          Login with Github
+          Continue with Github
         </Button>
       </div>
     </div>

--- a/src/pages/Login/PosterLogin.js
+++ b/src/pages/Login/PosterLogin.js
@@ -9,7 +9,7 @@ const useStyles = makeStyles((theme) => ({
     color: '#ffffff',
     backgroundColor: '#3b5998',
     margin: 15,
-    width: 250,
+    width: 270,
     '&:hover, &:focus': {
       backgroundColor: '#003069'
     }
@@ -42,7 +42,7 @@ export default function PosterLogin() {
 
   return (
     <div className={classes.poster}>
-      <Typography variant="h6">Login as a poster</Typography>
+      <Typography variant="h6">Sign up or login as a poster</Typography>
       <div className={classes.btnContainer}>
         <Button
           variant="contained"
@@ -50,7 +50,7 @@ export default function PosterLogin() {
           href="http://localhost:5000/auth/facebook"
         >
           <FacebookIcon className={classes.icon} />
-          Login with Facebook
+          Continue with Facebook
         </Button>
         <Button
           variant="outlined"
@@ -58,7 +58,7 @@ export default function PosterLogin() {
           className={classes.button}
         >
           <img src={GoogleLogo} alt="google" className={classes.img} />
-          Login with Google
+          Continue with Google
         </Button>
       </div>
     </div>

--- a/src/pages/Login/PosterLogin.js
+++ b/src/pages/Login/PosterLogin.js
@@ -23,8 +23,8 @@ const useStyles = makeStyles((theme) => ({
   icon: {
     marginRight: 10
   },
-  button: {
-    width: 250
+  google: {
+    width: 270
   },
   img: {
     height: 22,
@@ -55,7 +55,7 @@ export default function PosterLogin() {
         <Button
           variant="outlined"
           href="http://localhost:5000/auth/google"
-          className={classes.button}
+          className={classes.google}
         >
           <img src={GoogleLogo} alt="google" className={classes.img} />
           Continue with Google


### PR DESCRIPTION
**Sign up text**

- Amended text on login card to reference 'sign up' as well as login to make it clear that this is how users can register with App Factory
- Changed button text to say 'continue' rather than login to account for initial registration and subsequent login (amended width of button to account for smaller screen sizes)

**Profile picture**

- Changed src to fix issue with FB and Google photos not being displayed. Added '|| Open Menu' into curly braces.
- Removed mouseOver functionality from the profile picture. When testing this on a mobile view, the mouseOver functionality was preventing the onClick opening of the menu. Just having onClick functionality does not detract from the UX. 